### PR TITLE
fix code ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+* text=auto
+
+*.html.haml text
+*.html.erb text
+*.yml text
+*.feature text
+Gemfile text
+Gemfile.lock text
+*.rake text
+Rakefile text
+*.rdoc text
+
+*.eot binary
+*.ttf binary
+*.woff binary


### PR DESCRIPTION
By creating `.gitattributes`, ending style in different platform will be
handled properly regardless of the user's preference. This would be useful if
anyone would like to develop under Windows.

Note that some file type is not listed; I believe Git has proper default rule for them.

I am actually not sure about these three binary files. Anyone know about fonts?